### PR TITLE
Refactored schema parameter

### DIFF
--- a/anyblok_bus/adapter.py
+++ b/anyblok_bus/adapter.py
@@ -1,0 +1,13 @@
+# This file is a part of the AnyBlok / Bus api project
+#
+#    Copyright (C) 2018 Jean-Sebastien SUZANNE <jssuzanne@anybox.fr>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+from json import loads
+
+
+def schema_adapter(registry, body, schema=None, **kwargs):
+    schema.context['registry'] = registry
+    return schema.load(loads(body))

--- a/anyblok_bus/tests/test_consumer.py
+++ b/anyblok_bus/tests/test_consumer.py
@@ -7,8 +7,7 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 from anyblok.tests.testcase import DBTestCase
 from anyblok.config import Configuration
-from anyblok_bus.consumer import (
-    bus_consumer, SchemaException, BusConfigurationException)
+from anyblok_bus.consumer import (bus_consumer, BusConfigurationException)
 from anyblok_bus.bloks.bus.exceptions import TwiceQueueConsumptionException
 from marshmallow import Schema, fields
 from json import dumps
@@ -59,18 +58,6 @@ class TestValidator(DBTestCase):
             @bus_consumer(queue_name='test', schema=schema)
             def decorated_method(cls, body=None):
                 return body
-
-    def test_whithout_schema(self):
-        with self.assertRaises(SchemaException):
-            self.init_registry(self.add_in_registry, schema=None)
-
-    def test_schema_whitout_load_method(self):
-
-        class WrongSchema:
-            pass
-
-        with self.assertRaises(SchemaException):
-            self.init_registry(self.add_in_registry, schema=WrongSchema)
 
     def test_schema_ok(self):
         registry = self.init_registry(self.add_in_registry, schema=OneSchema())

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -18,6 +18,15 @@ CHANGELOG
 * Refactored bus console script, Added processes parameter on bus_consumer.
   The goal is to define processes for one queue, by default all the queues 
   are in the same process
+* Added adapter parameter to transform bus message, the schema attribute
+  become now a simple kwargs argument give to adapter.
+
+  The adapter is not required.
+
+  .. note::
+  
+      To keep the compatibility, if no adapter is defined with a schema then
+      the adapter is schema_adapter
 
 1.1.0 (2018-09-15)
 ------------------


### PR DESCRIPTION
Added adapter parameter to transform bus message, the schema attribute
become now a simple kwargs argument give to adapter.

The adapter is not needed.

To keep the compatibility, if no adapter is defined with a schema then
the adapter is schema_adapter